### PR TITLE
Delete blog

### DIFF
--- a/Delivery/Controllers/blog_controller.go
+++ b/Delivery/Controllers/blog_controller.go
@@ -89,3 +89,17 @@ func (bc *BlogController) UpdateBlogHandler(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, updatedBlog)
 }
+
+func (bc *BlogController) DeleteBlog(ctx *gin.Context) {
+	blogID := ctx.Param("id")
+	userID, ok := getAuthenticatedUserID(ctx)
+	if !ok {
+		return
+	}
+	userRole := ctx.GetString("role")
+	if err := bc.blogUsecase.DeleteBlog(ctx, blogID, userID, userRole); err != nil {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "Blog deleted successfully"})
+}

--- a/Delivery/Router/router.go
+++ b/Delivery/Router/router.go
@@ -24,6 +24,7 @@ func SetupRouter(uc *controllers.UserController, ac *controllers.AuthController,
 	{
 		blogRoutes.POST("/",authMiddleware.Middleware(),bc.CreateBlogHandler)
 		blogRoutes.PUT("/:id",authMiddleware.Middleware(),bc.UpdateBlogHandler)
+		blogRoutes.DELETE("/:id",authMiddleware.Middleware(),bc.DeleteBlog)
 	}
 
 	return router

--- a/Domain/blog.go
+++ b/Domain/blog.go
@@ -20,13 +20,13 @@ type IBlogRepository interface {
 	Create(ctx context.Context, blog *Blog) (*Blog, error)
 	FindByID(ctx context.Context, BlogID string) (*Blog, error)
 	// GetByUser(ctx context.Context, user *User) (*Blog, error)
-	// Delete(ctx context.Context, blog *Blog) (error)
+	DeleteBlog(ctx context.Context, blog *Blog) error
 	Update(ctx context.Context, blog *Blog) (*Blog, error)
 }
 type IBlogUsecase interface {
 	Create(ctx context.Context, blog *Blog) error
-	// Delete(ctx context.Context, blog *Blog) error
 	Update(ctx context.Context, input UpdateBlogInput) (*Blog, error)
+	DeleteBlog(ctx context.Context, blogID, userID, userRole string) error
 	// Search(ctx context.Context, blogid string) error
 	// Filtration(ctx context.Context) error
 	// PopulatityTracking(ctx context.Context) error

--- a/Repositories/blog_repository.go
+++ b/Repositories/blog_repository.go
@@ -12,26 +12,26 @@ import (
 )
 
 type blogModel struct {
-	ID             primitive.ObjectID `bson:"_id"`
-	Title          string             `bson:"title"`
-	Content        string             `bson:"content"`
-	UserID         string		  	  `bson:"user_id"`
-	Tags           []string			  `bson:"tags"`
-	ViewCount 	   int				  `bson:"view_count"`
-	CreatedAt      time.Time          `bson:"createdAt"`
-	UpdatedAt      time.Time          `bson:"updatedAt"`
+	ID        primitive.ObjectID `bson:"_id"`
+	Title     string             `bson:"title"`
+	Content   string             `bson:"content"`
+	UserID    string             `bson:"user_id"`
+	Tags      []string           `bson:"tags"`
+	ViewCount int                `bson:"view_count"`
+	CreatedAt time.Time          `bson:"createdAt"`
+	UpdatedAt time.Time          `bson:"updatedAt"`
 }
 
 func toDomainBlog(m blogModel) domain.Blog {
 	return domain.Blog{
-		ID:             m.ID.Hex(),
-		Title:          m.Title,
-		Content:        m.Content,
-		Tags:			m.Tags,
-		UserID:			m.UserID,
-		ViewCount: 		m.ViewCount,
-		CreatedAt:      m.CreatedAt,
-		UpdatedAt:      m.UpdatedAt,
+		ID:        m.ID.Hex(),
+		Title:     m.Title,
+		Content:   m.Content,
+		Tags:      m.Tags,
+		UserID:    m.UserID,
+		ViewCount: m.ViewCount,
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.UpdatedAt,
 	}
 }
 
@@ -50,14 +50,14 @@ func (r *blogRepository) Create(ctx context.Context, blog *domain.Blog) (*domain
 	blog.ID = blogObjectID.Hex()
 
 	doc := bson.M{
-		"_id":             blogObjectID,
-		"title":           blog.Title,
-		"content":         blog.Content,
-		"tags":            blog.Tags,
-		"view_count": 	   blog.ViewCount,
-		"user_id":         blog.UserID,
-		"createdAt":       blog.CreatedAt,
-		"updatedAt":       blog.UpdatedAt,
+		"_id":        blogObjectID,
+		"title":      blog.Title,
+		"content":    blog.Content,
+		"tags":       blog.Tags,
+		"view_count": blog.ViewCount,
+		"user_id":    blog.UserID,
+		"createdAt":  blog.CreatedAt,
+		"updatedAt":  blog.UpdatedAt,
 	}
 
 	_, err := r.blogCollection.InsertOne(ctx, doc)
@@ -108,4 +108,16 @@ func (r *blogRepository) Update(ctx context.Context, blog *domain.Blog) (*domain
 	}
 
 	return blog, nil
+}
+
+func (r *blogRepository) DeleteBlog(ctx context.Context, blog *domain.Blog) error {
+	objID, err := primitive.ObjectIDFromHex(blog.ID)
+	if err != nil {
+		return fmt.Errorf("invalid blog ID: %w", err)
+	}
+	_, err = r.blogCollection.DeleteOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		return fmt.Errorf("failed to delete blog: %w", err)
+	}
+	return nil
 }

--- a/Usecases/blog_usecase.go
+++ b/Usecases/blog_usecase.go
@@ -20,7 +20,7 @@ func NewBlogUseCase(blogRepo domain.IBlogRepository) domain.IBlogUsecase {
 func (bu *BlogUsecase) Create(ctx context.Context, blog *domain.Blog) error {
 
 	if blog.Title == "" || blog.Content == "" || len(blog.Tags) == 0 {
-		return  fmt.Errorf("invalid input: title/content/tags must not be empty")
+		return fmt.Errorf("invalid input: title/content/tags must not be empty")
 	}
 	_, err := bu.blogRepository.Create(ctx, blog)
 
@@ -58,4 +58,15 @@ func (bu *BlogUsecase) Update(ctx context.Context, input domain.UpdateBlogInput)
 	}
 
 	return updatedBlog, nil
+}
+
+func (bu *BlogUsecase) DeleteBlog(ctx context.Context, blogID, userID, userRole string) error {
+	blog, err := bu.blogRepository.FindByID(ctx, blogID)
+	if err != nil {
+		return fmt.Errorf("blog not found")
+	}
+	if blog.UserID != userID && userRole != "admin" {
+		return fmt.Errorf("unauthorized: only the author or admin can delete this blog")
+	}
+	return bu.blogRepository.DeleteBlog(ctx, blog)
 }


### PR DESCRIPTION
This pull request adds the ability to delete blogs, including endpoint, usecase, repository, and interface updates. The deletion logic ensures that only the blog's author or an admin can perform the delete operation.

**Blog Deletion Feature:**

* Added `DeleteBlog` handler to `BlogController`, which checks user authentication and authorization before deleting a blog.
* Registered the `DELETE /blogs/:id` route in the router with authentication middleware.

**Domain and Interface Updates:**

* Updated the `IBlogRepository` and `IBlogUsecase` interfaces to include `DeleteBlog` methods for deleting blogs by ID.

**Repository and Usecase Implementation:**

* Implemented the `DeleteBlog` method in `blogRepository` to remove a blog from the database by its ID.
* Implemented the `DeleteBlog` method in `BlogUsecase` to verify permissions and call the repository deletion logic.